### PR TITLE
kalico: filter single-sample impulses from the hx711s probe trigger feed

### DIFF
--- a/meta-opencentauri/recipes-apps/klipper/kalico_2026.02.00.inc
+++ b/meta-opencentauri/recipes-apps/klipper/kalico_2026.02.00.inc
@@ -4,7 +4,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=1ebbd3e34237af26da5dc08a4e440464"
 
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
-SRC_URI = "git://github.com/OpenCentauri/kalico.git;protocol=https;branch=hx711s-new2 \
+SRC_URI = "git://github.com/OpenCentauri/kalico.git;protocol=https;branch=paul/hx711s-phantom \
     file://0001-remove-save-config-subfile-check.patch \
     file://0002-reduce-calibration-difference-tolerance.patch \
     file://0001-Reduce-log-rotate-threshold.patch \
@@ -13,9 +13,9 @@ SRC_URI = "git://github.com/OpenCentauri/kalico.git;protocol=https;branch=hx711s
     file://0001-probe-home-z-includes-z-offset.patch \
     file://0001-force-specific-input-shaper.patch \
 "
-SRCREV = "3f166182f82f95584112571b4f7b2258922be60d"
+SRCREV = "13c5cfc77db1b54043310517a25143f20e11c9c4"
 
-PR = "r9"
+PR = "r10"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
## TL;DR (plain language)

The printer sometimes thinks it touched the bed when it didn't — a split-second blip in the load-cell signal (vibration or electrical noise) looks identical to a real touch, so probing stops mid-air and retries ("Bad probe detected"). This adds a tiny filter: any jump that big has to stick around for **two readings in a row** before we believe it. Real touches always do; noise never does.

**Lingo:** *load cell* = the force sensors under the bed. *tap* = the nozzle touching the bed to measure its height. *impulse* = a one-reading spike in the force signal. *trigger* = the "we touched!" decision. *80SPS* = the sensors report 80 times per second.

Credit: builds on @jamesturton's hx711s-new2 driver work and community reports (harrym's bad-probe log); analysis + implementation by @pdscomp & Lucy (bot).

## What this is

One kalico commit on top of `hx711s-new2` (`3f166182`), living on kalico branch **`paul/hx711s-phantom`** — this cosmos PR just repoints the recipe at it (+34/−2 lines in `src/sensor_hx711s.c`, single call site). Structured as a branch (not a recipe patch) so it can become a kalico PR directly.

## The problem (evidence)

- **User report:** "Bad probe detected, retrying" at z≈17.7mm — the probe "triggered" in mid-air at the descent-start height, twice at nearly identical z (17.67, 17.66), then worked on retry 4 once the transient passed.
- **Capture data:** in a 197k-sample raw force capture (5× full bed mesh @60C on hx711s-new2): **3 single-sample impulses (76–78g, one sample wide, instantly reverting)** in travel/arm zones. Rare — but one landing in the arming window = phantom trigger (same class behind "triggered prior to movement" and TAP_CHRONOLOGY failures on the old driver).

## How Elegoo's stock firmware handles this (context)

Their bed-MCU firmware (`elegooofficial/CentauriCarbon`, `mcu/src/hx711s.c`) never trusts single samples:

1. **Stream layer:** sliding-window exception filter on each sensor *and* the fused sum (+ median filter on raw frames) — outlier samples are dropped before they pollute anything.
2. **Trigger layer:** shape validation — the last 3 samples must be monotonically increasing and the largest in the window, slope into the final point >40°, plus an explicit `enable_shake_filter` (手拍干扰/桌子振动干扰 = "hand-tap/table-vibration interference") that rejects positive-going spikes in the window.

The vendor guards this exact fault class at two layers. Kalico's probe trigger is threshold-on-filtered-sum — a 1-sample spike walks straight through it.

## The fix (the simplest version that works)

Hold-and-confirm at the single probe-feed call site:

- A jump >~55g in one sample is **held back** — the trigger sees the previous baseline that round
- The next sample decides: still elevated → real ramp, forward it (**+1 sample latency**, 12.5ms @80SPS); back at baseline → impulse, **dropped**, never reaches the trigger

## Validation (offline replay over the same 197k capture)

- **0/3 impulses survive** the 55g threshold; **0/465 real taps lost**
- Trigger latency: uniform 1 sample (median 11.6ms, max 23.3ms)
- Synthetic opposite-sign pair (+76g/−76g): nothing leaks; genuine 80g step: confirmed with 1-sample latency

## Files changed

| File | Change |
|---|---|
| `meta-opencentauri/recipes-apps/klipper/kalico_2026.02.00.inc` | kalico branch `hx711s-new2` → `paul/hx711s-phantom`, SRCREV → `13c5cfc7`, PR r10 |

## Notes

- Threshold 5775 counts ≈ 55g on CC1 (~105 counts/g). Rule: must sit below `trigger_force × counts_per_gram` — scale if calibration differs.
- Deliberately minimal: no tunables/host plumbing. If this looks good, the kalico-side PR can add a configurable threshold later; the core protection doesn't need it.
- This seems like the simplest way to filter out these phantom taps inside kalico's architecture — the heavier alternative (porting Elegoo's windowed shape-checker) is a much bigger change. Happy to iterate.
