### PR TITLE
DragonBreath chamber heater support

### DIFF
--- a/meta-opencentauri/images/opencentauri-image-base.bb
+++ b/meta-opencentauri/images/opencentauri-image-base.bb
@@ -47,6 +47,7 @@ CORE_IMAGE_EXTRA_INSTALL += "\
     chrony \
     afc \
     tmc-autotune \ 
+    dragonbreath \
 "
 
 INITRAMFS_IMAGE = "core-image-tiny-initramfs"

--- a/meta-opencentauri/recipes-data/klipper-dragonbreath-addon/dragonbreath_0.1.bb
+++ b/meta-opencentauri/recipes-data/klipper-dragonbreath-addon/dragonbreath_0.1.bb
@@ -1,0 +1,32 @@
+HOMEPAGE = "https://github.com/plastikman/dragonbreath-klipper"
+LICENSE = "GPL-3.0-only"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=ff1231f0087400bc406945200e2f0ef0"
+SUMMARY = "dragonbreath-klipper"
+DESCRIPTION = "Klipper module for the DragonBreath-firmware Panda Breath chamber heater."
+
+SRC_URI = "git://github.com/plastikman/dragonbreath-klipper.git;protocol=https;branch=main"
+
+# Pinned deliberately. The device firmware owns all heater policy, so bump this
+# only after testing the module against a current DragonBreath release.
+# Requires API v2: device firmware 1.0.0 or newer, unchanged through v1.1.10.
+SRCREV = "c5f531b656599e3574571e534c83ec39a78de0b5"
+
+S = "${WORKDIR}/git"
+
+RDEPENDS:${PN} = " \
+    klipper \
+"
+
+do_configure[noexec] = "1"
+do_compile[noexec] = "1"
+
+do_install() {
+    # Module only. The config the user adds to printer.cfg to enable it is
+    # documented rather than shipped, so nothing here can activate itself.
+    install -d ${D}${datadir}/klipper/klippy/extras
+    install -m 0644 ${S}/dragonbreath.py ${D}${datadir}/klipper/klippy/extras/dragonbreath.py
+}
+
+FILES:${PN} = " \
+    ${datadir}/klipper/klippy/extras/dragonbreath.py \
+"


### PR DESCRIPTION
Reopens the content of #288, rebased onto current main. That PR was merged on 19 Aug and is no longer present on main following a history rewrite; this puts the code back on the table so the technical discussion can happen against the diff.

One commit, two files, +33/-0. Installs the pinned dragonbreath-klipper module into klippy/extras and adds the package to the image. Nothing else: no config shipped, no cosmos.conf setting, no generated config, no device discovery, no existing file modified beyond the one image line. It does nothing until a user adds a `[dragonbreath]` section to printer.cfg.

The rebase had one conflict, in `opencentauri-image-base.bb`, where `tmc-autotune` landed in the same spot. Resolved by keeping both.

## On the memory question

This was the main objection last time, so to put numbers on it. Kalico imports every module in `klippy/extras` at startup whether or not a config section references it, so a module's import cost is paid by every printer. The upstream module now defers `urllib` and `uuid` until a device is actually configured (plastikman/dragonbreath-klipper#6, included in this pin):

| | heap | modules |
|---|---|---|
| before | ~3553 KB | +57 |
| after | ~202 KB | +1 |

For reference, `AFC_utils.py` imports `urllib.request` at module scope, and `afc` is unconditionally in `CORE_IMAGE_EXTRA_INSTALL`, so the interpreter already carries that cost on every image today. This change does not add a new one — configured, it reuses what is already resident; unconfigured, it costs ~200 KB of bytecode.

## Verification

- CI built the image on the previous revision of this branch.
- Built the recipe standalone against the pinned layer revisions on an aarch64 host, before and after the rebase. Package contains exactly one file, `/usr/share/klipper/klippy/extras/dragonbreath.py`, no QA warnings.
- Confirmed `dragonbreath` and `tmc-autotune` both resolve in `CORE_IMAGE_EXTRA_INSTALL` after the conflict resolution.
- Tested on hardware. Testers built and flashed it: the module loads, the heater appears with a live chamber temperature (50.2 C against the printer's own chamber sensor reading 48.7 C), and it reconciles to off at target 0 on connect, which is the expected state. At least one user has since run a full print with the chamber heated through the module. That also exercises the lease heartbeat, since the device only sustains heat while its controller keeps renewing.

Not deliberately exercised, since these have to be provoked rather than observed in a normal run: watchdog latch-off on forced comms loss, and fault injection and recovery. Both are device-firmware paths; the module supplies intent and holds a lease.

## Setup, for the docs

Flash and provision the device, select Klipper/Moonraker as its control source and point it at this printer's Moonraker, give it a static lease or resolvable hostname, then paste into printer.cfg, set host, and Save & Restart.

```ini
[dragonbreath]
host: 192.168.1.100    # the device's IP address or hostname
#port: 80
#token: web            # match the control token set on the device, if any
#poll_interval: 2.0    # polling fallback / retry interval, SSE is the normal path
#register_macros: True # registers M141/M191

[heater_generic dragonbreath]
heater_pin: dragonbreath:pwm
sensor_type: dragonbreath
control: watermark
max_delta: 2.0
min_temp: 0
max_temp: 75           # the device hard-caps the requested target at 70c

[verify_heater dragonbreath]
max_error: 600
check_gain_time: 360
hysteresis: 5
heating_gain: 1

[output_pin dragonbreath_filter]
pin: dragonbreath:filter
value: 0
shutdown_value: 0
```

Chamber preheat is deliberately not touched here. With `CHAMBER_PREHEAT` now split out on main, a DragonBreath user overrides it in printer.cfg:

```ini
[gcode_macro CHAMBER_PREHEAT]
gcode:
    {% set target = [params.TARGET|default(0)|int, 70]|min %}
    {% if target > 0 %}
        {% if "xyz" not in printer.toolhead.homed_axes %}
            G28
        {% endif %}
        SET_DISPLAY_TEXT MSG="Chamber: {target}c"
        SET_HEATER_TEMPERATURE HEATER=dragonbreath TARGET={target}
        M106 S255
        G0 X128 Y128 Z10 F9000
        TEMPERATURE_WAIT SENSOR="heater_generic dragonbreath" MINIMUM={target}
        M107
    {% endif %}
```

The clamp matters because the device will not accept a target above 70 C, so waiting on a higher number never completes.

Module pinned at c5f531b. Requires API v2, so device firmware 1.0.0 or newer; the API is unchanged through v1.1.10.

Open for discussion on approach — happy to take it in a different direction if there is one the maintainers prefer.
