### PR TITLE
fluidd/mainsail: default off built-in Screws Tilt Adjust dialogs

### DIFF
--- a/meta-opencentauri/recipes-apps/fluidd/files/opencentauri-fluidd-theme/apply-opencentauri-fluidd-theme.py
+++ b/meta-opencentauri/recipes-apps/fluidd/files/opencentauri-fluidd-theme/apply-opencentauri-fluidd-theme.py
@@ -174,8 +174,6 @@ def patch_main_bundle(webroot):
 def patch_state_chunk(webroot):
     """Patch the initial Vuex state so OpenCentauri is the default theme."""
     chunks = sorted((webroot / "assets").glob("state-*.js"))
-    if not chunks:
-        return  # Not all builds have this chunk
 
     old_theme = "theme:{isDark:!0,logo:{src:`logo_fluidd.svg`},color:`#2196F3`,backgroundLogo:!0}"
     new_theme = f"theme:{{isDark:!0,logo:{{src:`{LOGO_SRC}`}},color:`{PRIMARY_COLOR}`,backgroundLogo:!0}}"
@@ -188,6 +186,59 @@ def patch_state_chunk(webroot):
             return  # Patched successfully
 
     raise RuntimeError(f"{webroot}/assets: expected hardcoded default theme not found in any state chunk")
+
+
+def patch_screws_tilt_default(webroot):
+    """Default off Fluidd's built-in Screws Tilt Adjust auto-popup.
+
+    The MANUAL_LEVELING/_SCREWS_TILT_PROMPT macros (cosmos#248) are the
+    leveling UX; Fluidd's native dialog stacks on top of them. Users can
+    re-enable via Settings -> Toolhead.
+    """
+    old = "showScrewsTiltAdjustDialogAutomatically:!0"
+    new = "showScrewsTiltAdjustDialogAutomatically:!1"
+    for path in sorted((webroot / "assets").glob("state-*.js")):
+        text = path.read_text(encoding="utf-8")
+        if old in text:
+            if text.count(old) != 1:
+                raise RuntimeError(f"{path}: expected 1x {old!r}, found {text.count(old)}")
+            path.write_text(text.replace(old, new), encoding="utf-8")
+            return
+    raise RuntimeError(f"{webroot}/assets: fluidd screws-tilt default not found in any state chunk")
+
+
+def verify_final(webroot):
+    """Fail the build if any OpenCentauri patch is missing from the final webroot.
+
+    Checks end state (not the pre-patch strings) so it also catches a patch
+    that matched the wrong occurrence in a newer upstream build.
+    """
+    errors = []
+
+    index = (webroot / "index.html").read_text(encoding="utf-8")
+    if f'data-fluidd-theme="{APP_NAME}"' not in index:
+        errors.append("index.html: missing data-fluidd-theme")
+    if THEME_CSS not in index:
+        errors.append("index.html: missing theme css link")
+
+    config = json.loads((webroot / "config.json").read_text(encoding="utf-8"))
+    if config.get("theme", {}).get("logo", {}).get("src") != LOGO_SRC:
+        errors.append("config.json: default theme is not OpenCentauri")
+
+    bundle = "".join(p.read_text(encoding="utf-8") for p in (webroot / "assets").glob("index-*.js"))
+    if "dataset.fluiddTheme" not in bundle:
+        errors.append("main bundle: onThemeChange patch missing")
+
+    state = "".join(p.read_text(encoding="utf-8") for p in (webroot / "assets").glob("state-*.js"))
+    if f"logo:{{src:`{LOGO_SRC}`}}" not in state:
+        errors.append("state chunk: default theme logo not patched")
+    if "showScrewsTiltAdjustDialogAutomatically:!0" in state:
+        errors.append("state chunk: screws-tilt dialog default still ON")
+    if state.count("showScrewsTiltAdjustDialogAutomatically:!1") != 1:
+        errors.append("state chunk: screws-tilt dialog default not patched exactly once")
+
+    if errors:
+        raise RuntimeError("fluidd webroot verification failed:\n  - " + "\n  - ".join(errors))
 
 
 def verify_assets(webroot):
@@ -208,6 +259,8 @@ def main():
     patch_config(webroot)
     patch_main_bundle(webroot)
     patch_state_chunk(webroot)
+    patch_screws_tilt_default(webroot)
+    verify_final(webroot)
 
 
 if __name__ == "__main__":

--- a/meta-opencentauri/recipes-apps/mainsail/files/apply-opencentauri-mainsail-patches.py
+++ b/meta-opencentauri/recipes-apps/mainsail/files/apply-opencentauri-mainsail-patches.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Default off Mainsail's built-in Screws Tilt Adjust dialog.
+
+The MANUAL_LEVELING/_SCREWS_TILT_PROMPT macros (cosmos#248) are the
+leveling UX; Mainsail's native dialog stacks on top of them. Users can
+re-enable via Settings -> Interface.
+"""
+import sys
+from pathlib import Path
+
+
+def replace_exact(text, old, new, count, path):
+    found = text.count(old)
+    if found != count:
+        raise RuntimeError(f"{path}: expected {count}x {old[:60]!r}, found {found}")
+    return text.replace(old, new)
+
+
+def main():
+    if len(sys.argv) != 2:
+        raise SystemExit(f"usage: {Path(sys.argv[0]).name} /path/to/mainsail-webroot")
+    webroot = Path(sys.argv[1])
+    bundles = sorted((webroot / "assets").glob("index-*.js"))
+    if len(bundles) != 1:
+        raise RuntimeError(f"{webroot}: expected exactly one assets/index-*.js bundle, found {len(bundles)}")
+    path = bundles[0]
+    text = path.read_text(encoding="utf-8")
+    # Store default (fresh settings DBs)
+    text = replace_exact(text, "boolScrewsTiltAdjustDialog:!0", "boolScrewsTiltAdjustDialog:!1", 1, path)
+    # `?? true` fallbacks in the dialog + settings-page getters (old DBs missing the key)
+    text = replace_exact(
+        text,
+        "uiSettings.boolScrewsTiltAdjustDialog)==null?!0:e",
+        "uiSettings.boolScrewsTiltAdjustDialog)==null?!1:e",
+        2,
+        path,
+    )
+    path.write_text(text, encoding="utf-8")
+
+    # Verify end state independently of the apply step (catches wrong-occurrence
+    # patches and upstream layouts where a second defaults object appears).
+    final = path.read_text(encoding="utf-8")
+    if final.count("boolScrewsTiltAdjustDialog:!1") != 1:
+        raise RuntimeError(f"{path}: screws-tilt dialog default not patched exactly once")
+    if "boolScrewsTiltAdjustDialog:!0" in final:
+        raise RuntimeError(f"{path}: screws-tilt dialog default still ON")
+    if final.count("uiSettings.boolScrewsTiltAdjustDialog)==null?!1:e") != 2:
+        raise RuntimeError(f"{path}: getter fallbacks not patched")
+    if "uiSettings.boolScrewsTiltAdjustDialog)==null?!0:e" in final:
+        raise RuntimeError(f"{path}: getter fallbacks still ON")
+
+
+if __name__ == "__main__":
+    main()

--- a/meta-opencentauri/recipes-apps/mainsail/mainsail_2.18.2.bb
+++ b/meta-opencentauri/recipes-apps/mainsail/mainsail_2.18.2.bb
@@ -5,9 +5,13 @@ HOMEPAGE = "https://github.com/mainsail-crew/mainsail"
 LICENSE = "GPL-3.0-only"
 LIC_FILES_CHKSUM = "file://index.html;md5=e041ea1952fb60d9e673d6c3f4d16802"
 
+inherit python3native
+
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
-SRC_URI = "https://github.com/mainsail-crew/mainsail/releases/download/v${PV}/mainsail.zip;subdir=mainsail"
+SRC_URI = "https://github.com/mainsail-crew/mainsail/releases/download/v${PV}/mainsail.zip;subdir=mainsail \
+    file://apply-opencentauri-mainsail-patches.py \
+"
 SRC_URI[sha256sum] = "df2ba7c301f7bfc8ac9f122741a6ba08356d679ecfa1f62f898d0337802d5de5"
 
 S = "${WORKDIR}/mainsail"
@@ -29,6 +33,7 @@ do_install() {
     # Install static web files
     install -d ${D}/var/www/mainsail
     cp -r ${S}/* ${D}/var/www/mainsail/
+    ${PYTHON} ${WORKDIR}/apply-opencentauri-mainsail-patches.py ${D}/var/www/mainsail
 
 }
 


### PR DESCRIPTION
## TL;DR (plain language)

When you run screw-based bed leveling, Fluidd and Mainsail each pop **their own** built-in "Screws Tilt Adjust" window on top of the new Klipper-prompt leveling flow from #248. Two competing UIs showing the same numbers is garbage soup. This PR turns the frontends' popups **off by default** in the shipped image, so the prompt-based flow is the only thing on screen. Anyone who misses the old window can re-enable it (Fluidd: Settings → Toolhead; Mainsail: Settings → Interface).

**Pairs with #248** (@Bad-Hackerman's macro side—this PR is the frontend counterpart). Ship together: without #248, stock `SCREWS_TILT_CALCULATE` falls back to console-text output only.

**Lingo:** STC = `SCREWS_TILT_CALCULATE` (the Klipper command that probes over each bed screw). "The dialog" = each frontend's native Screws Tilt Adjust popup, which auto-opens whenever STC results arrive.

## Files changed

| File | Change |
|---|---|
| `meta-opencentauri/recipes-apps/fluidd/files/opencentauri-fluidd-theme/apply-opencentauri-fluidd-theme.py` | New `patch_screws_tilt_default()` flips Fluidd's shipped store default off. New `verify_final()` independently re-checks the end state of **every** patch (theme included). Also removed a now-dead silent-success path in `patch_state_chunk`. |
| `meta-opencentauri/recipes-apps/mainsail/files/apply-opencentauri-mainsail-patches.py` | **New**—flips Mainsail's shipped store default off, plus the two `?? true` getter fallbacks (covers settings DBs that predate the key), with exact-occurrence assertions and an end-state verify pass. |
| `meta-opencentauri/recipes-apps/mainsail/mainsail_2.18.2.bb` | Runs the patch script in `do_install` (adds `inherit python3native` + the script to `SRC_URI`). Mirrors the fluidd recipe's existing pattern. |

## Why patch minified bundles, and why it's safe (check methodology)

Fair question—string surgery on minified JS is normally where maintainability goes to die. Here's why this instance is the right tool, and why it can't silently rot:

1. **There is no config-file route (verified against the shipped zips).** Fluidd's `config.json` carries only `blacklist`/`endpoints`/`hosted`/`themePresets`; Mainsail's carries only `defaultLocale`/`defaultMode`/`defaultTheme`/`hostname`/`instances*`. Neither feeds `uiSettings` defaults. The defaults exist *only* in the minified store state inside the release zips, so package-install time is the one place we control them.
2. **The match anchors are API-stable by construction.** We match on the persisted setting keys (`showScrewsTiltAdjustDialogAutomatically`, `boolScrewsTiltAdjustDialog`). Those strings are serialized into users' moonraker settings DBs—upstream can't rename them without orphaning every existing user's saved preference. Minification mangles everything *around* the keys; the keys themselves must survive. We never reference chunk content-hashes or minified variable names (globs only).
3. **Exact-occurrence assertions.** Each replacement asserts its expected count (1 for both defaults, 2 for Mainsail's fallbacks). A newer upstream build that grows a second defaults object—or drops one—fails `do_install` instead of patching the wrong occurrence.
4. **Independent end-state verify.** After patching, each script re-reads the final webroot and asserts the desired state (off-forms present exactly N times, on-forms absent). Fluidd's verify also re-checks every theme marker, closing a silent hole in the existing theme patcher.
5. **It runs inside `do_install`, so it survives updates by construction.** The zip is sha256-pinned; upstream can't drift under us. A version bump that moves the strings turns the bump PR's build red with the offending path in the error—loud failure aimed at exactly the person who can fix it, instead of a quietly unpatched dialog shipping to printers.
6. **Doubles as the version-bump smoke test.** `unzip mainsail.zip && python3 apply-opencentauri-mainsail-patches.py webroot/`—a non-zero exit means the patch needs porting. No separate tooling to maintain.

## Verification

- `bitbake -c cleansstate fluidd mainsail && bitbake fluidd mainsail`—all 1903 tasks green.
- Packaged webroots: fluidd `state-*.js` has exactly 1× `showScrewsTiltAdjustDialogAutomatically:!1` and 0× `:!0`; mainsail `index-*.js` has 1× `boolScrewsTiltAdjustDialog:!1`, 2× `==null?!1:e` fallbacks, 0 remaining on-forms; OpenCentauri theme markers intact.
- Fail-hard proven: re-running either script against an already-patched (or string-drifted) tree raises `RuntimeError` with the path.
- Reviewed (twice) with a severity-ranked code review pass; findings (`encoding="utf-8"` hygiene, one dead code path) fixed and re-verified.

## Caveats

- Printers whose moonraker DB already holds an explicit `true` for these keys keep the popup—saved user settings correctly win over shipped defaults. Fresh flashes, and anyone who never touched the toggle, get the new default.
- Re-enabling is one settings toggle in either frontend, no reflash needed.
