### PR TITLE
Add support for skew profiles

### DIFF
--- a/meta-opencentauri/recipes-apps/klipper/files/macros.cfg
+++ b/meta-opencentauri/recipes-apps/klipper/files/macros.cfg
@@ -115,6 +115,7 @@ gcode:
         LINE_PURGE
     {% endif %}
     SET_TEMPERATURE_FAN_TARGET temperature_fan=mainboard TARGET=30
+    LOAD_SKEW_IF_EXISTS
     SET_DISPLAY_TEXT ; Clear display text after print start
     G90
 
@@ -147,6 +148,8 @@ gcode:
     {% set toolhead_led = settings.toolhead_led|default('false')|lower == 'true' %}
     {% set e_mintemp  = printer.configfile.settings['extruder'].min_extrude_temp %}
     {% set sensor = printer['filament_switch_sensor filament_sensor'] if 'filament_switch_sensor filament_sensor' in printer else printer["filament_switch_sensor extruder_tool_start"] %}
+
+    CLEAR_SKEW_IF_EXISTS
   
     {% if printer.toolhead.homed_axes|lower == "xyz" %}
         G91
@@ -817,3 +820,28 @@ gcode:
 [gcode_macro M8213]
 gcode:
     { action_emergency_stop("Use COSMOS OrcaSlicer profile (or COSMOS start/end machine gcode).") }
+
+[gcode_macro LOAD_SKEW_IF_EXISTS]
+gcode:
+  {% set profile = params.PROFILE|default('my_skew_profile') %}
+  {% set section = "skew_correction " ~ profile %}
+
+  # Check if the section '[skew_correction your_profile_name]' exists in the config
+  {% if section in printer.configfile.config %}
+    RESPOND MSG="Skew profile '{profile}' found. Loading..."
+    SKEW_PROFILE LOAD={profile}
+  {% else %}
+    RESPOND PREFIX="Info:"  "No skew profile defined. If skew correction is desired, create '{profile}' in printer.cfg"
+  {% endif %}
+
+[gcode_macro CLEAR_SKEW_IF_EXISTS]
+gcode:
+  {% set profile = params.PROFILE|default('my_skew_profile') %}
+  {% set section = "skew_correction " ~ profile %}
+
+  # Only clear if the profile is actively configured or exists
+  {% if section in printer.configfile.config %}
+    RESPOND MSG="Clearing Skew Profile"
+    SET_SKEW CLEAR=1
+  {% endif %}
+

--- a/meta-opencentauri/recipes-apps/klipper/files/macros.cfg
+++ b/meta-opencentauri/recipes-apps/klipper/files/macros.cfg
@@ -524,11 +524,10 @@ gcode:
         G1 E-{retract_length} F300 ; Retract filament
     {% endif %}
 
-    # TODO: This can probably be faster
-    G0 Y20 F12000
-    G0 X255 F12000
-    G0 Y4 F1200
-    G0 Y20 F1200
+    G0 Y30 F12000     ;back up to y30 to give some runway
+    G0 X255 F12000    ;move to x cutting position
+    G0 Y4 F18000      ;cut - move from Y30 to Y4 (26mm runway) at 300 mm/s
+    G0 Y20 F1200      ;retract slowly to clear housing
 
     {% if printer.extruder.target >= 180 and printer.extruder.can_extrude %}
         MOVE_TO_TRAY

--- a/meta-opencentauri/recipes-apps/klipper/files/macros.cfg
+++ b/meta-opencentauri/recipes-apps/klipper/files/macros.cfg
@@ -221,7 +221,10 @@ gcode:
     {% endif %}  
 
     SET_DISPLAY_TEXT MSG="Pausing"
-
+	
+	#while paused, we may CUT_FILAMENT, MOVE_TO_TRAY, rehome, or any other number of near boundry movements
+	CLEAR_SKEW_IF_EXISTS
+	 
     _SAVE_FAN_STATE
     PAUSE_BASE
     TURN_OFF_FANS
@@ -288,6 +291,9 @@ gcode:
         M400
         SAVE_GCODE_STATE NAME=PAUSE_STATE
     {% endif %}
+	
+	# reload SKEW which was cleared at start of PAUSE.  If the skew was purposfully or accidentally loaded by some other mechanism, there is no harm in doing it again
+	LOAD_SKEW_IF_EXISTS
 
     RESUME_BASE
 

--- a/meta-opencentauri/recipes-apps/klipper/files/macros.cfg
+++ b/meta-opencentauri/recipes-apps/klipper/files/macros.cfg
@@ -524,8 +524,7 @@ gcode:
         G1 E-{retract_length} F300 ; Retract filament
     {% endif %}
 
-    G0 Y30 F12000     ;back up to y30 to give some runway
-    G0 X255 F12000    ;move to x cutting position
+    G0 X255 Y30 F18000      ;move to cut start position
     G0 Y4 F18000      ;cut - move from Y30 to Y4 (26mm runway) at 300 mm/s
     G0 Y20 F1200      ;retract slowly to clear housing
 

--- a/meta-opencentauri/recipes-apps/klipper/files/macros.cfg
+++ b/meta-opencentauri/recipes-apps/klipper/files/macros.cfg
@@ -832,7 +832,7 @@ gcode:
     RESPOND MSG="Skew profile '{profile}' found. Loading..."
     SKEW_PROFILE LOAD={profile}
   {% else %}
-    RESPOND PREFIX="Info:"  "No skew profile defined. If skew correction is desired, create '{profile}' in printer.cfg"
+    RESPOND PREFIX="Info:"  MSG="No skew profile defined. If skew correction is desired, create '{profile}' in printer.cfg"
   {% endif %}
 
 [gcode_macro CLEAR_SKEW_IF_EXISTS]

--- a/meta-opencentauri/recipes-apps/klipper/files/macros.cfg
+++ b/meta-opencentauri/recipes-apps/klipper/files/macros.cfg
@@ -524,9 +524,10 @@ gcode:
         G1 E-{retract_length} F300 ; Retract filament
     {% endif %}
 
-    G0 X255 Y30 F18000      ;move to cut start position
-    G0 Y4 F18000      ;cut - move from Y30 to Y4 (26mm runway) at 300 mm/s
-    G0 Y20 F1200      ;retract slowly to clear housing
+    G0 X245 Y30 F18000    ;preposition before cut
+    G0 X255 F18000        ;move to cut start position
+    G0 Y4 F18000          ;cut - move from Y30 to Y4 (26mm runway) at 300 mm/s
+    G0 Y20 F1200          ;retract slowly to clear housing
 
     {% if printer.extruder.target >= 180 and printer.extruder.can_extrude %}
         MOVE_TO_TRAY


### PR DESCRIPTION
A simplified rework of previous pull.  Assumes a skew profile will be called 'my_skew_profile' (used in klipper documentation and AFC plugin)
-if the profile exists, load it at the end of PRINT_START
-if the profile does not exist, do nothing.  notify the user they are welcome to create one
-load/unload during resume

https://github.com/OpenCentauri/cosmos/issues/236