### PR TITLE
update-cosmos: publish download and install progress for the on-screen updater

### DIFF
--- a/meta-opencentauri/recipes-data/update-scripts/files/update-cosmos
+++ b/meta-opencentauri/recipes-data/update-scripts/files/update-cosmos
@@ -13,14 +13,55 @@ case "$RELEASE" in
 esac
 
 SWUFILE="/user-resource/update.swu"
+STATUS_FILE="/run/cosmos-update.status"
+
+# Publish progress so the on screen UI can show what is happening. Written to a
+# temp file and renamed so a reader never observes a partially written line.
+# Format: <state>|<percent>
+# state: downloading | flashing | rebooting | failed
+write_status() {
+    echo "$1|$2" > "${STATUS_FILE}.tmp" 2>/dev/null \
+        && mv "${STATUS_FILE}.tmp" "$STATUS_FILE" 2>/dev/null \
+        || true
+}
+
+write_status downloading 0
+
+# Size of the asset after redirects, so bytes on disk can be turned into a
+# percentage. If this fails we simply report 0 and the UI shows an
+# indeterminate download rather than failing the update.
+TOTAL=$(curl -k -sIL "$FW_URL" \
+    | awk '/^[Cc]ontent-[Ll]ength:/ {v=$2} END {gsub(/\r/,"",v); print v+0}')
 
 # Download firmware
-curl -k -f -S -o "$SWUFILE" -L "$FW_URL"
+curl -k -f -S -o "$SWUFILE" -L "$FW_URL" &
+CURL_PID=$!
+
+while kill -0 "$CURL_PID" 2>/dev/null; do
+    if [ "$TOTAL" -gt 0 ] && [ -f "$SWUFILE" ]; then
+        CUR=$(wc -c < "$SWUFILE" || echo 0)
+        write_status downloading $(( CUR * 100 / TOTAL ))
+    fi
+    sleep 1
+done
+
+if ! wait "$CURL_PID"; then
+    write_status failed 0
+    exit 1
+fi
+
+write_status downloading 100
 
 # Install firmware
-flash "$SWUFILE"
+write_status flashing 0
+if ! flash "$SWUFILE"; then
+    write_status failed 0
+    exit 1
+fi
 
 # Clean up firmware file
 rm "$SWUFILE"
+
+write_status rebooting 100
 
 reboot


### PR DESCRIPTION
## What

`update-cosmos` now writes its state to `/run/cosmos-update.status` as a single `<state>|<percent>` line, with state one of `downloading`, `flashing`, `rebooting`, `failed`, so a UI can show what is happening. The file is written to a temporary name and renamed, so a reader never sees a partial line, and every write ends in `|| true`, so status reporting can never fail the update itself.

Download progress comes from the asset size (`curl -sIL` and the last `Content-Length`; GitHub's release CDN answers HEAD with the real size on the final hop, 124226048 bytes for both the stable and nightly asset) against `wc -c` of the partial file, sampled once a second while `curl` runs in the background. If the size is unavailable the percentage simply stays at 0 and the download proceeds as before. A `curl` failure or a `flash` failure writes `failed` before exiting non-zero.

The consumer is pellcorp/grumpyscreen#287, which reads exactly this path by default, so no recipe change is needed on the cosmos side.

Behaviour is otherwise identical: same URLs, same `flash`, same cleanup, same `reboot`, same exit codes.

## Tested

On a Centauri Carbon running 26.08.0 with a grumpyscreen build that reads the file: live percentage through the whole 124 MB download, "Installing" during the flash, then the reboot; the printer came back with its config untouched. `/run` is tmpfs on this image and `/bin/sh` is BusyBox ash with 64-bit arithmetic, so `bytes * 100` cannot overflow.
