### PR TITLE
afc.cfg: define _AFC_GLOBAL_VARS so the BT_* helper macros work

### DIFF
--- a/meta-opencentauri/recipes-data/klipper-afc-addon/files/afc.cfg
+++ b/meta-opencentauri/recipes-data/klipper-afc-addon/files/afc.cfg
@@ -3,6 +3,15 @@
 # UPDATES WILL RESET THIS FILE. YOUR EDITS WILL BE LOST WHEN UPDATING.
 # -----
 
+# Variables shared by the BT_* helper macros below. Upstream AFC ships these in
+# AFC_Macro_Vars.cfg; COSMOS only needs the ones its macros read.
+[gcode_macro _AFC_GLOBAL_VARS]
+description: Global variables used in multiple macros
+gcode: # Leave Empty
+variable_stepper_name             : 'CANVAS_'  # Lane name prefix, BT_CHANGE_TOOL LANE=2 becomes CHANGE_TOOL LANE=CANVAS_2
+variable_disable_skew_correction  : False      # When True macros disable and re-enable skew correction around kinematic moves
+variable_verbose                  : 1          # Console output for macros
+
 # Eject Loaded Lane
 [gcode_macro BT_TOOL_UNLOAD]
 description: Unloads the currently loaded lane


### PR DESCRIPTION

`BT_CHANGE_TOOL`, `BT_LANE_EJECT`, `BT_LANE_MOVE`, `AFC_DISABLE_SKEW` and `AFC_ENABLE_SKEW` in the shipped `afc.cfg` all read `printer['gcode_macro _AFC_GLOBAL_VARS']`. Upstream AFC defines that section in `AFC_Macro_Vars.cfg`, which COSMOS does not ship, so every one of those macros fails with a Jinja error the first time someone tries them.

This adds the section with the three variables the shipped macros use, with the lane prefix set to `CANVAS_`, so `BT_CHANGE_TOOL LANE=2` becomes `CHANGE_TOOL LANE=CANVAS_2`.

A user who already defined `_AFC_GLOBAL_VARS` in `printer.cfg` keeps working: Klipper merges duplicate sections and the later one wins.

## Tested

On a CC1 with CANVAS on 26.08.0 with this section in `printer.cfg` (same content): `BT_LANE_EJECT LANE=2` resolves to `LANE_UNLOAD LANE=CANVAS_2` and runs; without the section it fails with `'gcode_macro _AFC_GLOBAL_VARS'` undefined.

Related: the lane eject those macros call is being enabled in the AFC fork (suchmememanyskill/AFC-Klipper-Add-On#1); once that lands the AFC recipe's SRCREV can move.
