### PR TITLE
macros: restore absolute positioning after PRINT_END and before homing Z

### DIFF
--- a/meta-opencentauri/recipes-apps/klipper/files/macros.cfg
+++ b/meta-opencentauri/recipes-apps/klipper/files/macros.cfg
@@ -182,6 +182,7 @@ gcode:
             {% endif %}
         {% endif %}
 
+        G90 ; back to absolute positioning, MOVE_TO_TRAY returns early when already at the tray
         MOVE_TO_TRAY
     {% endif %}
     TURN_OFF_FANS
@@ -573,6 +574,7 @@ gcode:
         G28 Y
     {% endif %}
     {% if 'Z' in rawparams %}
+        G90 ; the FORCE_MOVE branch above leaves whatever positioning mode was active
         G0 X128 Y128 F6000
         G28 Z
     {% endif %}


### PR DESCRIPTION

After cancelling a print that is paused at the purge tray, every homing attempt fails with

```
Move out of range: 364.000 156.000 170.527 [...]
```

until Klipper is restarted. That includes the screen's Home button and AFC's auto-home on a `T<n>` command, so on a CANVAS machine a runout followed by a cancel leaves the user unable to load the next spool.

## Why

`PRINT_END` (which `CANCEL_PRINT` calls) switches to `G91` for its lift and relies on `MOVE_TO_TRAY` to switch back with `G90`. `MOVE_TO_TRAY` returns early when the head is already at the tray, which is exactly where a paused print sits, so relative mode stays active. `M84` then unhomes the axes. On the next `G28` the `[homing_override]` takes its `FORCE_MOVE` branch (Z not homed), which issues no `G90` either, so its `G0 X128 Y128` runs as a relative move from the post-homing position (X 236, Y 28 after the homing retracts) and Klipper refuses X 364.

## Fix

- `PRINT_END`: `G90` before `MOVE_TO_TRAY`, so the macro restores absolute mode itself.
- `[homing_override]`: `G90` before `G0 X128 Y128`, so homing works regardless of the mode a previous macro left behind.

## Tested

Reproduced on a CC1 with CANVAS on 26.08.0: runout pause at the tray, cancel, `T0` → the error above four times in a row, cleared only by a reboot. The klippy log confirmed relative mode and the unhomed state after the cancel, and the failing coordinates are 128 + the post-homing position on X and Y with Z at the 170 mm cancel lift.
