### PR TITLE
canvas: put the purge-end retract back before returning to the print

### DIFF
--- a/meta-opencentauri/recipes-data/klipper-afc-addon/files/canvas.cfg
+++ b/meta-opencentauri/recipes-data/klipper-afc-addon/files/canvas.cfg
@@ -233,6 +233,9 @@ gcode:
     G1 X165 ; Wipe left
     G1 X190 ; Wipe right
     G1 X165 ; Wipe left
+    G1 E{retract_amount} F300 ; Undo the retract: AFC goes straight back to the print after this
+    G1 X190 F8000 ; One more swipe to shed the bead that makes
+    G1 X165
 
     M106 S0 ; Turn off fan
 


### PR DESCRIPTION

Every colour on a CANVAS print starts short by `retract_amount` of filament, and this is why.

`KICK` retracts `retract_amount` (2 mm by default) after the tray purge so the wipe does not ooze, and nothing ever un-retracts it. AFC restores the saved print position as soon as the tool change ends, so the head is already back on the part when the slicer's G-code resumes. Orca slices with relative extrusion, so it only un-retracts the retract it did itself; it has no idea about the macro's. The first `retract_amount` of extrusion after a change just refills the melt zone.

With the default 2 mm through a 0.8 nozzle at 0.4 mm layers that is roughly 15 mm of thin line at the start of every colour region (about 60 mm with 0.4 mm lines and 0.2 mm layers). Against a light it shows as a crescent-shaped gap at the start of each perimeter after a change, and as light through the part at the colour boundaries.

The change is three lines in `KICK`: after the last wipe, while still over the wiper, un-retract the same amount and take one more swipe to shed the small bead that makes. The travel back to the print then happens in the same state as any other travel in the print, with only the slicer's own retract in effect, and the first perimeter after a change starts at full flow.

`macros.cfg` has its own `KICK` for the non-CANVAS path; it is left alone because a purge line follows it before printing starts.

## Tested

Centauri Carbon with CANVAS, COSMOS 26.08.0, four wood PLA lanes, 0.8 nozzle, a 4-colour concentric-ring coin with 25 changes per print. Before: a crescent gap along the outer ring's inner boundary and a gap around the centre disc on every print, visible against a light. After: both gone on the first print with the change, no other settings touched. Also verified in the sliced file that Orca's tool-change "extra length on restart" cannot substitute for this: Orca 2.4.2 drops it, and even if it did not, the un-retract would land on the part after AFC's own return move.
