### PR TITLE
klipper: keep klippy resident in RAM

### DIFF
--- a/meta-opencentauri/recipes-apps/klipper/files/0005-mlock-keep-klippy-resident.patch
+++ b/meta-opencentauri/recipes-apps/klipper/files/0005-mlock-keep-klippy-resident.patch
@@ -1,0 +1,72 @@
+diff --git a/klippy/extras/mlock.py b/klippy/extras/mlock.py
+new file mode 100644
+index 0000000..ee7bac9
+--- /dev/null
++++ b/klippy/extras/mlock.py
+@@ -0,0 +1,66 @@
++# Keep klippy resident in RAM.
++#
++# Klipper has hard real-time deadlines towards the MCUs (trsync during
++# homing, the move queue during a print). On a host with little RAM and an
++# aggressive swap policy the kernel is free to page klippy out, and a major
++# page fault at the wrong moment shows up as "Timer too close" or "Unable to
++# obtain 'trsync_state' response". Locking the process in memory takes the
++# kernel out of that decision.
++#
++# [mlock]
++#
++# Copyright (C) 2026  COSMOS contributors
++#
++# This file may be distributed under the terms of the GNU GPLv3 license.
++import ctypes
++import logging
++import resource
++
++MCL_CURRENT = 1
++MCL_FUTURE = 2
++# Lock pages as they are first touched instead of faulting the whole address
++# space in at once (Linux 4.4+). Falls back to a plain lock if unsupported.
++MCL_ONFAULT = 4
++
++
++class MemLock:
++    def __init__(self, config):
++        printer = config.get_printer()
++        try:
++            resource.setrlimit(
++                resource.RLIMIT_MEMLOCK,
++                (resource.RLIM_INFINITY, resource.RLIM_INFINITY),
++            )
++        except (ValueError, OSError) as e:
++            logging.warning("mlock: could not raise RLIMIT_MEMLOCK: %s", e)
++        libc = ctypes.CDLL(None, use_errno=True)
++        flags = MCL_CURRENT | MCL_FUTURE
++        rc = libc.mlockall(flags | MCL_ONFAULT)
++        if rc != 0 and ctypes.get_errno() == 22:  # EINVAL: no MCL_ONFAULT
++            rc = libc.mlockall(flags)
++        if rc != 0:
++            err = ctypes.get_errno()
++            logging.warning("mlock: mlockall failed: errno %d", err)
++            return
++        printer.register_event_handler("klippy:ready", self._report)
++
++    def _report(self):
++        try:
++            with open("/proc/self/status") as f:
++                st = dict(
++                    l.split(":", 1)
++                    for l in f
++                    if l.startswith(("VmLck", "VmRSS", "VmSwap"))
++                )
++            logging.info(
++                "mlock: locked %s resident %s swapped %s",
++                st.get("VmLck", "?").strip(),
++                st.get("VmRSS", "?").strip(),
++                st.get("VmSwap", "?").strip(),
++            )
++        except OSError:
++            pass
++
++
++def load_config(config):
++    return MemLock(config)

--- a/meta-opencentauri/recipes-apps/klipper/files/machine.cfg
+++ b/meta-opencentauri/recipes-apps/klipper/files/machine.cfg
@@ -48,6 +48,11 @@ path: /etc/klipper/gcodes
 [danger_options]
 multi_mcu_trsync_timeout: 0.03
 
+# Keep klippy resident in RAM: with 117 MB and swappiness 150 the kernel
+# otherwise pages it out, and a page fault during homing or a print ends in
+# "Timer too close".
+[mlock]
+
 [stepper_x]
 step_pin: PE8
 dir_pin: !PE7

--- a/meta-opencentauri/recipes-apps/klipper/kalico_2026.02.00.inc
+++ b/meta-opencentauri/recipes-apps/klipper/kalico_2026.02.00.inc
@@ -14,6 +14,7 @@ SRC_URI = "git://github.com/OpenCentauri/kalico.git;protocol=https;branch=hx711s
     file://0001-force-specific-input-shaper.patch \
     file://0003-drv8833-motor-control.patch \
     file://0004-allow-config-exclude.patch \
+    file://0005-mlock-keep-klippy-resident.patch \
 "
 SRCREV = "3f166182f82f95584112571b4f7b2258922be60d"
 


### PR DESCRIPTION

This is the "Timer too close" that several of us have hit at print start (see the comments on #312). I chased one on a Centauri Carbon with CANVAS today and it is not CPU load, it is swap latency.

**What happened.** Orca uploaded a 7.5 MB G-code file and started the print three seconds later. Moonraker was still parsing the file for metadata. Five seconds in, the first `G28 Y` failed with `Unable to obtain 'trsync_state' response` and the main MCU shut down with `Timer too close`. Host load was 0.2, nothing was printing yet.

**Why.** The board has 117 MB of RAM and the zram init sets `vm.swappiness` to 150, so the kernel prefers to page program memory out over dropping file cache. Sampling `/proc` once a second on an idle printer: klippy had 35 MB of its 48 MB in swap and was taking a handful of major page faults every second. During an upload it took about 150 faults in one second, its resident size fell to 10 MB and free memory to 7 MB. That is the state klippy was in when the MCU needed its trsync reply within a few milliseconds.

All processes together use only 40 MB resident, so this is not a shortage of RAM, it is the swap policy applied to the one process with hard deadlines.

**Fix.** A small Kalico module, `[mlock]`, that at startup raises `RLIMIT_MEMLOCK` (the default is 8 MB) and calls `mlockall(MCL_CURRENT | MCL_FUTURE | MCL_ONFAULT)`, falling back to a plain `mlockall` on kernels without `MCL_ONFAULT`. It logs what it locked once klippy is ready. Shipped as one more patch in the Kalico recipe, enabled with `[mlock]` in `machine.cfg` next to `[danger_options]`.

**Measured with it.** klippy 46 MB resident, 6 MB of never-touched pages left in swap. Through the same upload and metadata parse: zero page faults, resident size unchanged. Moonraker took the paging instead, which it does not mind. Upload-and-print from Orca then homed and started normally, and the printer went on through a three-hour, 85-change CANVAS print with a pause, a file swap and a cancel in the middle, no Timer too close, no page faults on klippy.

Trade-off: about 48 MB of the 117 MB is now pinned. Free memory sits around 8 to 13 MB with the camera streamer running, and Moonraker lives a bit more in swap. Nothing else changed: `swappiness` stays at 150, since that was benchmarked for a reason, and this only takes klippy out of that decision.

`swappiness` alone would only shift the odds; locking the process makes the timing independent of what Moonraker, the camera or a file upload are doing.
